### PR TITLE
Fix add landmark dialog not opening

### DIFF
--- a/Client/src/components/LandmarkMap.vue
+++ b/Client/src/components/LandmarkMap.vue
@@ -104,6 +104,11 @@ export default {
       showDialog.value = true;
     };
 
+    const openAddDialog = () => {
+      selectedLandmark.value = null;
+      showDialog.value = true;
+    };
+
     const closeDialog = () => showDialog.value = false;
 
     const saveLandmark = async () => {
@@ -118,6 +123,16 @@ export default {
       closeDialog();
     };
 
+    const centerMap = () => {
+      if (mapRef.value && mapRef.value.mapObject) {
+        if (landmarks.value.length) {
+          updateMapView();
+        } else {
+          mapRef.value.mapObject.setView(center.value, zoom.value);
+        }
+      }
+    };
+
     return {
       landmarks,
       selectedLandmark,
@@ -128,9 +143,11 @@ export default {
       mapRef,
       getIconForTag,
       selectLandmark,
+      openAddDialog,
       closeDialog,
       saveLandmark,
       deleteLandmark,
+      centerMap,
     };
   },
 };


### PR DESCRIPTION
## Summary
- add an `openAddDialog` handler to the map component so the parent button can launch the landmark dialog
- expose a `centerMap` helper so the parent map centering control works even without markers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1389b1968832f989109a0f5ac8ba8