### PR TITLE
Enable Quasar dialog plugin for delete confirmation

### DIFF
--- a/Client/quasar.conf.js
+++ b/Client/quasar.conf.js
@@ -99,7 +99,7 @@ module.exports = configure(function (ctx) {
       // directives: [],
 
       // Quasar plugins
-      plugins: ['Notify']
+      plugins: ['Notify', 'Dialog']
     },
 
     // animations: 'all', // --- includes all animations


### PR DESCRIPTION
## Summary
- enable the Quasar Dialog plugin so the bulk delete confirmation dialog can open again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d13cd7dbf8832f9e717b776f0fd4f6